### PR TITLE
backward_incompat: Don't use SHA1 files

### DIFF
--- a/archive/20.2.0-380-gdbcbbd3f281/backward_incompat/OSDMap/242fae989276d844ac0744c5baeb77bc
+++ b/archive/20.2.0-380-gdbcbbd3f281/backward_incompat/OSDMap/242fae989276d844ac0744c5baeb77bc
@@ -1,1 +1,0 @@
-archive/20.2.0-380-gdbcbbd3f281/objects/OSDMap/242fae989276d844ac0744c5baeb77bc

--- a/archive/20.2.0-380-gdbcbbd3f281/backward_incompat/OSDMap/f99554077432a66d714de0d8e155fc3f
+++ b/archive/20.2.0-380-gdbcbbd3f281/backward_incompat/OSDMap/f99554077432a66d714de0d8e155fc3f
@@ -1,1 +1,0 @@
-archive/20.2.0-380-gdbcbbd3f281/objects/OSDMap/f99554077432a66d714de0d8e155fc3f

--- a/archive/20.2.0-380-gdbcbbd3f281/backward_incompat/OSDMap/fb05b99ed1233ad9646484de554b40bd
+++ b/archive/20.2.0-380-gdbcbbd3f281/backward_incompat/OSDMap/fb05b99ed1233ad9646484de554b40bd
@@ -1,1 +1,0 @@
-archive/20.2.0-380-gdbcbbd3f281/objects/OSDMap/fb05b99ed1233ad9646484de554b40bd

--- a/archive/20.2.0-380-gdbcbbd3f281/backward_incompat/OSDMap/fb4a55321ce7d737c42e4510cb592c9a
+++ b/archive/20.2.0-380-gdbcbbd3f281/backward_incompat/OSDMap/fb4a55321ce7d737c42e4510cb592c9a
@@ -1,1 +1,0 @@
-archive/20.2.0-380-gdbcbbd3f281/objects/OSDMap/fb4a55321ce7d737c42e4510cb592c9a

--- a/archive/20.2.0-380-gdbcbbd3f281/backward_incompat/OSDMap/fc6c1d44f6ce37b3136b7c9ccda6d9fb
+++ b/archive/20.2.0-380-gdbcbbd3f281/backward_incompat/OSDMap/fc6c1d44f6ce37b3136b7c9ccda6d9fb
@@ -1,1 +1,0 @@
-archive/20.2.0-380-gdbcbbd3f281/objects/OSDMap/fc6c1d44f6ce37b3136b7c9ccda6d9fb

--- a/archive/20.2.0-380-gdbcbbd3f281/backward_incompat/OSDMap/fc93c53ae54c6772b33e977e3485925c
+++ b/archive/20.2.0-380-gdbcbbd3f281/backward_incompat/OSDMap/fc93c53ae54c6772b33e977e3485925c
@@ -1,1 +1,0 @@
-archive/20.2.0-380-gdbcbbd3f281/objects/OSDMap/fc93c53ae54c6772b33e977e3485925c

--- a/archive/20.2.0-380-gdbcbbd3f281/backward_incompat/OSDMap::Incremental/0b137d1c3bc4e499f5d41386a6be693d
+++ b/archive/20.2.0-380-gdbcbbd3f281/backward_incompat/OSDMap::Incremental/0b137d1c3bc4e499f5d41386a6be693d
@@ -1,1 +1,0 @@
-archive/20.2.0-380-gdbcbbd3f281/objects/OSDMap::Incremental/0b137d1c3bc4e499f5d41386a6be693d

--- a/archive/20.2.0-380-gdbcbbd3f281/backward_incompat/OSDMap::Incremental/f9a71dccb95b0d4f0446886a0ebfa4ee
+++ b/archive/20.2.0-380-gdbcbbd3f281/backward_incompat/OSDMap::Incremental/f9a71dccb95b0d4f0446886a0ebfa4ee
@@ -1,1 +1,0 @@
-archive/20.2.0-380-gdbcbbd3f281/objects/OSDMap::Incremental/f9a71dccb95b0d4f0446886a0ebfa4ee

--- a/archive/20.2.0-380-gdbcbbd3f281/backward_incompat/OSDMap::Incremental/fb9d9a96f2af15739c7ea59ce56fb23d
+++ b/archive/20.2.0-380-gdbcbbd3f281/backward_incompat/OSDMap::Incremental/fb9d9a96f2af15739c7ea59ce56fb23d
@@ -1,1 +1,0 @@
-archive/20.2.0-380-gdbcbbd3f281/objects/OSDMap::Incremental/fb9d9a96f2af15739c7ea59ce56fb23d

--- a/archive/20.2.0-380-gdbcbbd3f281/backward_incompat/bluefs_fnode_t/ff9cdf39308547be6d935e4ae6cbc734
+++ b/archive/20.2.0-380-gdbcbbd3f281/backward_incompat/bluefs_fnode_t/ff9cdf39308547be6d935e4ae6cbc734
@@ -1,1 +1,0 @@
-archive/20.2.0-380-gdbcbbd3f281/objects/bluefs_fnode_t/ff9cdf39308547be6d935e4ae6cbc734

--- a/archive/20.2.0-380-gdbcbbd3f281/backward_incompat/bluefs_super_t/f8f27a400eb6762edcfaa8c6eff9f365
+++ b/archive/20.2.0-380-gdbcbbd3f281/backward_incompat/bluefs_super_t/f8f27a400eb6762edcfaa8c6eff9f365
@@ -1,1 +1,0 @@
-archive/20.2.0-380-gdbcbbd3f281/objects/bluefs_super_t/f8f27a400eb6762edcfaa8c6eff9f365

--- a/archive/20.2.0-380-gdbcbbd3f281/backward_incompat/pg_pool_t/d623ccd2ac1e62debdbc06dbeb4f0484
+++ b/archive/20.2.0-380-gdbcbbd3f281/backward_incompat/pg_pool_t/d623ccd2ac1e62debdbc06dbeb4f0484
@@ -1,1 +1,0 @@
-archive/20.2.0-380-gdbcbbd3f281/objects/pg_pool_t/d623ccd2ac1e62debdbc06dbeb4f0484

--- a/archive/20.2.0-380-gdbcbbd3f281/backward_incompat/pg_pool_t/fcdfdd4ba18e5a00b576087d738d54a9
+++ b/archive/20.2.0-380-gdbcbbd3f281/backward_incompat/pg_pool_t/fcdfdd4ba18e5a00b576087d738d54a9
@@ -1,1 +1,0 @@
-archive/20.2.0-380-gdbcbbd3f281/objects/pg_pool_t/fcdfdd4ba18e5a00b576087d738d54a9

--- a/archive/20.2.0-380-gdbcbbd3f281/backward_incompat/pg_pool_t/fd3c9a5c20f11f891010bb0e732f98a4
+++ b/archive/20.2.0-380-gdbcbbd3f281/backward_incompat/pg_pool_t/fd3c9a5c20f11f891010bb0e732f98a4
@@ -1,1 +1,0 @@
-archive/20.2.0-380-gdbcbbd3f281/objects/pg_pool_t/fd3c9a5c20f11f891010bb0e732f98a4

--- a/archive/20.2.0-380-gdbcbbd3f281/backward_incompat/pg_pool_t/fd4a700d4b69c47a9045e58bb16337ce
+++ b/archive/20.2.0-380-gdbcbbd3f281/backward_incompat/pg_pool_t/fd4a700d4b69c47a9045e58bb16337ce
@@ -1,1 +1,0 @@
-archive/20.2.0-380-gdbcbbd3f281/objects/pg_pool_t/fd4a700d4b69c47a9045e58bb16337ce

--- a/archive/20.2.0-380-gdbcbbd3f281/backward_incompat/pg_pool_t/fe0a1c1e28bb3746003ea8c864c5ed97
+++ b/archive/20.2.0-380-gdbcbbd3f281/backward_incompat/pg_pool_t/fe0a1c1e28bb3746003ea8c864c5ed97
@@ -1,1 +1,0 @@
-archive/20.2.0-380-gdbcbbd3f281/objects/pg_pool_t/fe0a1c1e28bb3746003ea8c864c5ed97

--- a/archive/20.2.0-380-gdbcbbd3f281/backward_incompat/pg_pool_t/fe2999763ae9eca2e7743388e8c355ed
+++ b/archive/20.2.0-380-gdbcbbd3f281/backward_incompat/pg_pool_t/fe2999763ae9eca2e7743388e8c355ed
@@ -1,1 +1,0 @@
-archive/20.2.0-380-gdbcbbd3f281/objects/pg_pool_t/fe2999763ae9eca2e7743388e8c355ed

--- a/archive/20.2.0-380-gdbcbbd3f281/backward_incompat/pg_pool_t/fe2f2c82375f55444b46126716d4c0c5
+++ b/archive/20.2.0-380-gdbcbbd3f281/backward_incompat/pg_pool_t/fe2f2c82375f55444b46126716d4c0c5
@@ -1,1 +1,0 @@
-archive/20.2.0-380-gdbcbbd3f281/objects/pg_pool_t/fe2f2c82375f55444b46126716d4c0c5

--- a/archive/20.2.0-380-gdbcbbd3f281/backward_incompat/pg_pool_t/ff8a0cf25b37e89d70cee314e52cb9c7
+++ b/archive/20.2.0-380-gdbcbbd3f281/backward_incompat/pg_pool_t/ff8a0cf25b37e89d70cee314e52cb9c7
@@ -1,1 +1,0 @@
-archive/20.2.0-380-gdbcbbd3f281/objects/pg_pool_t/ff8a0cf25b37e89d70cee314e52cb9c7

--- a/archive/20.2.0-380-gdbcbbd3f281/backward_incompat/pg_pool_t/ffa8beac0762223c9a2e23da7e2ecf7b
+++ b/archive/20.2.0-380-gdbcbbd3f281/backward_incompat/pg_pool_t/ffa8beac0762223c9a2e23da7e2ecf7b
@@ -1,1 +1,0 @@
-archive/20.2.0-380-gdbcbbd3f281/objects/pg_pool_t/ffa8beac0762223c9a2e23da7e2ecf7b

--- a/archive/20.2.0-380-gdbcbbd3f281/backward_incompat/pg_pool_t/ffb8fe52944b21b5a8945e3c2c707695
+++ b/archive/20.2.0-380-gdbcbbd3f281/backward_incompat/pg_pool_t/ffb8fe52944b21b5a8945e3c2c707695
@@ -1,1 +1,0 @@
-archive/20.2.0-380-gdbcbbd3f281/objects/pg_pool_t/ffb8fe52944b21b5a8945e3c2c707695


### PR DESCRIPTION
SHA1 files can be changed between versions, due to that, we won't skip
those type and still fail to test them.
use empty directory with the type name to skip all files for
backward_incompat instead.
